### PR TITLE
refactor: add support for AGP 8.0+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,12 +22,14 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    namespace 'com.ajinasokan.overlay_webview'
+
     compileSdkVersion 33
 
     defaultConfig {
         minSdkVersion 16
     }
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Tue Sep 24 15:05:35 IST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip


### PR DESCRIPTION
- Updated gradle to 7.2
- Added namespace inside build.gradle to support AGP 8.0+
- rename `lintOptions` to `lint` to support new syntax